### PR TITLE
chore: prilux-vial-ui to 0.0.192

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.407
 - name: prilux-vial-ui
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.190
+  version: 0.0.192
 - name: priluxswiftlibrary
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.202


### PR DESCRIPTION
chore: Promote prilux-vial-ui to version 0.0.192